### PR TITLE
drawer width issue with orientation change in ipad and iphone

### DIFF
--- a/DrawerMenu/Classes/DrawerMenu.swift
+++ b/DrawerMenu/Classes/DrawerMenu.swift
@@ -118,7 +118,11 @@ public class DrawerMenu: UIViewController, UIGestureRecognizerDelegate {
         changeStyle(style: style)
 
     }
-
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        changeRightMenuWidth()
+        changeLeftMenuWidth()
+    }
     // MARK: Public
     public func replace(center controller: UIViewController) {
 


### PR DESCRIPTION
- While changing the orientation in ipad and bigger iphones the drawer is slightly revealed automatically because of autoresizing mask. 
So to fix that I had to update the width on layout change